### PR TITLE
load-firewall: Pass pin location as CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ done with `attach-firewall`)
 ```
 go get -u github.com/iovisor/gobpf/elf
 make
-./load-firewall
+./load-firewall /sys/fs/bpf/cgroup-firewall-demo
 mkdir /sys/fs/cgroup/unified/cgroup-firewall-demo
 ./attach-firewall /sys/fs/bpf/cgroup-firewall-demo /sys/fs/cgroup/unified/cgroup-firewall-demo/
 ```

--- a/load-firewall.go
+++ b/load-firewall.go
@@ -9,6 +9,13 @@ import (
 )
 
 func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <path/to/pinned/firewall>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	progPath := os.Args[1]
+
 	if err := bpffs.Mount(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to mount bpf fs: %v\n", err)
 		os.Exit(1)
@@ -20,12 +27,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	pinPath := "/sys/fs/bpf/cgroup-firewall-demo"
 	progFd := firewall.CgroupProgram("cgroup/skb/firewall").Fd()
-	if err := elf.PinObject(progFd, pinPath); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to pin firewall at %q: %v\n", pinPath, err)
+	if err := elf.PinObject(progFd, progPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to pin firewall at %q: %v\n", progPath, err)
 		os.Exit(1)
 	}
 
-	fmt.Printf("Successfully pinned program at %q\n", pinPath)
+	fmt.Printf("Successfully pinned program at %q\n", progPath)
 }


### PR DESCRIPTION
Take the location where to pin the BPF program as a command-line argument instead of hardcode it in the source code.